### PR TITLE
feat(nodes): pass the library path in the context

### DIFF
--- a/zenoh-flow-nodes/src/context.rs
+++ b/zenoh-flow-nodes/src/context.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use zenoh_flow_commons::{InstanceId, RuntimeId};
 
@@ -27,15 +27,22 @@ pub struct Context {
     pub(crate) flow_name: Arc<str>,
     pub(crate) instance_id: InstanceId,
     pub(crate) runtime_id: RuntimeId,
+    pub(crate) library_path: Arc<PathBuf>,
 }
 
 impl Context {
     /// Creates a new node `Context`.
-    pub fn new(flow_name: Arc<str>, instance_id: InstanceId, runtime_id: RuntimeId) -> Self {
+    pub fn new(
+        flow_name: Arc<str>,
+        instance_id: InstanceId,
+        runtime_id: RuntimeId,
+        library_path: Arc<PathBuf>,
+    ) -> Self {
         Self {
             flow_name,
             instance_id,
             runtime_id,
+            library_path,
         }
     }
 
@@ -57,5 +64,12 @@ impl Context {
     /// on different Zenoh-Flow runtimes.
     pub fn runtime_id(&self) -> &RuntimeId {
         &self.runtime_id
+    }
+
+    /// Returns the path of the library loaded by the Zenoh-Flow runtime.
+    ///
+    /// The path is local to the machine where the Zenoh-Flow runtime is running.
+    pub fn library_path(&self) -> &PathBuf {
+        &self.library_path
     }
 }


### PR DESCRIPTION
Fixes #246.

As explained in #246, providing the path of the library that Zenoh-Flow loads is a requirement for developing extensions. For instance, in Python, the `pyo3` library needs to load the script.

This change adds the accessor method `library_path` to the `Context` structure, that returns a reference to the full path of the library being loaded.

* zenoh-flow-nodes/src/context.rs:
  - add the library_path field to the Context structure,
  - update the constructor accordingly,
  - add the accessor method `library_path()`.
* zenoh-flow-runtime/src/loader/mod.rs:
  - update the Loader structure to also store the path of the library that is being loaded,
  - update the code to account for the path of the library being also stored.
* zenoh-flow-runtime/src/runtime/load.rs:
  - remove the `Context` in the arguments of the `try_load_*` methods as it cannot be created at that stage but only when the nodes are loaded,
  - create the `Context` where appropriate.