### PR TITLE
feat(zenoh-plugin-zenoh-flow): provide "dynamic_plugin" feature

### DIFF
--- a/zenoh-plugin-zenoh-flow/Cargo.toml
+++ b/zenoh-plugin-zenoh-flow/Cargo.toml
@@ -23,6 +23,10 @@ name = "zenoh-plugin-zenoh-flow"
 repository = { workspace = true }
 version = { workspace = true }
 
+[features]
+dynamic_plugin = []
+default = ["dynamic_plugin"]
+
 [lib]
 crate-type = ["cdylib"]
 name = "zenoh_plugin_zenoh_flow"

--- a/zenoh-plugin-zenoh-flow/src/lib.rs
+++ b/zenoh-plugin-zenoh-flow/src/lib.rs
@@ -27,6 +27,7 @@ pub struct ZenohFlowPlugin(Sender<()>);
 
 pub const GIT_VERSION: &str = git_version::git_version!(prefix = "v", cargo_prefix = "v");
 
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(ZenohFlowPlugin);
 
 impl ZenohPlugin for ZenohFlowPlugin {}


### PR DESCRIPTION
Having this feature and, in particular, the ability to disable it, allows statically linking the Zenoh-Flow plugin to Zenoh.

This feature is enabled by default.

* zenoh-plugin-zenoh-flow/Cargo.toml: added the `dynamic_plugin` feature.
* zenoh-plugin-zenoh-flow/src/lib.rs: only call the macro `declare_plugin!` if the feature `dynamic_plugin` is enabled.