### PR TITLE
feat(zenoh-flow-nodes): expose node's node id in Context

### DIFF
--- a/zenoh-flow-nodes/src/context.rs
+++ b/zenoh-flow-nodes/src/context.rs
@@ -14,7 +14,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
-use zenoh_flow_commons::{InstanceId, RuntimeId};
+use zenoh_flow_commons::{InstanceId, NodeId, RuntimeId};
 
 /// The `Context` structure provides information about the data flow and the Zenoh-Flow runtime.
 ///
@@ -24,6 +24,7 @@ use zenoh_flow_commons::{InstanceId, RuntimeId};
 /// - the [runtime id](Context::runtime_id()) of the Zenoh-Flow runtime managing the **node**.
 #[derive(Clone, Debug)]
 pub struct Context {
+    pub(crate) node_id: NodeId,
     pub(crate) flow_name: Arc<str>,
     pub(crate) instance_id: InstanceId,
     pub(crate) runtime_id: RuntimeId,
@@ -37,12 +38,14 @@ impl Context {
         instance_id: InstanceId,
         runtime_id: RuntimeId,
         library_path: Arc<PathBuf>,
+        node_id: NodeId,
     ) -> Self {
         Self {
             flow_name,
             instance_id,
             runtime_id,
             library_path,
+            node_id,
         }
     }
 
@@ -71,5 +74,10 @@ impl Context {
     /// The path is local to the machine where the Zenoh-Flow runtime is running.
     pub fn library_path(&self) -> &PathBuf {
         &self.library_path
+    }
+
+    /// Returns the node unique identifier in the data flow.
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
     }
 }

--- a/zenoh-flow-runtime/src/runtime/load.rs
+++ b/zenoh-flow-runtime/src/runtime/load.rs
@@ -276,6 +276,7 @@ The channels for the Inputs and Outputs of Operator < {} > were not created.
                 record.instance_id().clone(),
                 self.runtime_id.clone(),
                 path,
+                operator_id.clone(),
             );
 
             let operator_node = (constructor)(
@@ -343,6 +344,7 @@ The channels for the Outputs of Source < {} > were not created.
                         record.instance_id().clone(),
                         self.runtime_id.clone(),
                         path,
+                        source_id.clone(),
                     );
 
                     let source_node =
@@ -424,6 +426,7 @@ The channels for the Inputs of Sink < {} > were not created.
                         record.instance_id().clone(),
                         self.runtime_id.clone(),
                         library_path,
+                        sink_id.clone(),
                     );
 
                     let sink_node =


### PR DESCRIPTION
This allows providing more accurate information in, for instance, logging. The same node could be instantiated several times, being able to add the `NodeId` to the logging information helps differentiating them.

* zenoh-flow-nodes/src/context.rs: add a field keeping track of the node id and a corresponding getter method.
* zenoh-flow-runtime/src/runtime/load.rs: add the operator, sink and source id when creating the Context.