### PR TITLE
fix(zenoh-flow-runtime): log wrapper path when failing to load it

### DIFF
--- a/zenoh-flow-runtime/src/loader/mod.rs
+++ b/zenoh-flow-runtime/src/loader/mod.rs
@@ -273,6 +273,9 @@ impl Loader {
                 if extension == std::env::consts::DLL_EXTENSION {
                     &library_path
                 } else {
+                    tracing::debug!(
+                        "Loading wrapper for non native dynamic library extension < {extension} >"
+                    );
                     self.extensions
                         .get_library_path(extension, node_symbol)
                         .ok_or_else(|| {
@@ -292,7 +295,7 @@ impl Loader {
 
         let rust_library_path = std::fs::canonicalize(rust_library_path).context(format!(
             "Failed to canonicalize path (did you put an absolute path?):\n{}",
-            library_path.display()
+            rust_library_path.display()
         ))?;
 
         #[cfg(any(target_family = "unix", target_family = "windows"))]


### PR DESCRIPTION
When the loading of a wrapper shared library failed, the path of the library to wrap was displayed instead of that of the wrapper.

This commit fixes this error and adds debug information when a wrapper shared library is about to be loaded.

* zenoh-flow-runtime/src/loader/mod.rs:
  - add debug logging information,
  - show wrapper path in error when loading it failed.