### PR TITLE
fix(zenoh-flow-nodes): provide accessors on `LinkMessage`

### DIFF
--- a/zenoh-flow-nodes/src/messages.rs
+++ b/zenoh-flow-nodes/src/messages.rs
@@ -147,7 +147,7 @@ pub struct LinkMessage {
 
 impl Ord for LinkMessage {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.get_timestamp().cmp(other.get_timestamp())
+        self.timestamp().cmp(other.timestamp())
     }
 }
 
@@ -159,19 +159,11 @@ impl PartialOrd for LinkMessage {
 
 impl PartialEq for LinkMessage {
     fn eq(&self, other: &Self) -> bool {
-        self.get_timestamp() == other.get_timestamp()
+        self.timestamp() == other.timestamp()
     }
 }
 
 impl Eq for LinkMessage {}
-
-impl Deref for LinkMessage {
-    type Target = Payload;
-
-    fn deref(&self) -> &Self::Target {
-        &self.payload
-    }
-}
 
 impl LinkMessage {
     pub fn new(payload: Payload, timestamp: Timestamp) -> Self {
@@ -188,10 +180,26 @@ impl LinkMessage {
         }
     }
 
+    /// Return the [Payload] associated with this [LinkMessage].
+    //
+    // NOTE: Used by our Python API. 🐍
+    pub fn payload(&self) -> &Payload {
+        &self.payload
+    }
+
+    /// Return the [Timestamp] associated with this message.
+    #[deprecated(
+        since = "0.6.0-alpha.3",
+        note = "This method will be deprecated in the next major version of Zenoh-Flow in favour of `timestamp()`."
+    )]
+    pub fn get_timestamp(&self) -> &Timestamp {
+        &self.timestamp
+    }
+
     /// Return the [Timestamp] associated with this message.
     //
-    // NOTE: This method is used by, at least, our Python API.
-    pub fn get_timestamp(&self) -> &Timestamp {
+    // NOTE: Used by our Python API. 🐍
+    pub fn timestamp(&self) -> &Timestamp {
         &self.timestamp
     }
 

--- a/zenoh-flow-runtime/src/runners/builtin/zenoh/sink.rs
+++ b/zenoh-flow-runtime/src/runners/builtin/zenoh/sink.rs
@@ -204,7 +204,7 @@ Caused by:
 
                 #[cfg(not(feature = "shared-memory"))]
                 {
-                    data.try_as_bytes_into(&mut payload_buffer)?;
+                    data.payload().try_as_bytes_into(&mut payload_buffer)?;
                     publisher
                         .put(payload_buffer)
                         .res()


### PR DESCRIPTION
Writing the Python bindings highlighted a tiny nuisance of the `Deref` trait: in order to access a Payload, an explicit turbofished call to Deref was required, which was not particularly ergonomic.

This commit introduces accessors for both the `payload` and `timestamp` fields of a `LinkMessage`.

The method `get_timestamp` was deprecated in favour of `timestamp`. This change is purely aesthetic and for coherence purposes.

* zenoh-flow-nodes/src/messages.rs:
  - removed the implementation of the Deref trait,
  - added an accessor `payload()`,
  - added an accessor `timestamp()`,
  - deprecated the accessor `get_timestamp()` in favour of `timestamp()`.
* zenoh-flow-runtime/src/runners/builtin/zenoh/sink.rs: as the Deref trait is no longer implemented on `LinkMessage`, a call to `payload()` is required.