### PR TITLE
fix(commons): do not fail without `Vars` section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,6 +3277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tracing",
  "uuid",
  "zenoh-keyexpr",
  "zenoh-protocol",

--- a/zenoh-flow-commons/Cargo.toml
+++ b/zenoh-flow-commons/Cargo.toml
@@ -31,6 +31,7 @@ humantime = "2.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 zenoh-keyexpr = { workspace = true }
 zenoh-protocol = { workspace = true }


### PR DESCRIPTION
If the `Vars` section was not present in a file that is parsed by the function `try_parse_from_file` then an error would be thrown.

This commit changes the behaviour of the function such that if it is missing, no error is returned and instead a log message is recorded.

* Cargo.lock: added dependency `tracing`.
* zenoh-flow-commons/Cargo.toml: added dependency `tracing`.

* zenoh-flow-commons/src/utils.rs: instead of throwing an error if the `Vars` section is missing, log a debug message and continue the normal execution.