### PR TITLE
docs: readme and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ authors = ["ZettaScale Zenoh Team <zenoh@zettascale.tech>"]
 categories = ["network-programming"]
 description = "Zenoh-Flow: a Zenoh-based data flow programming framework for computations that span from the cloud to the device."
 edition = "2021"
-homepage = "https://github.com/eclipse-zenoh/zenoh-flow"
+homepage = "https://github.com/eclipse-zenoh-flow/zenoh-flow"
 license = " EPL-2.0 OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/eclipse-zenoh/zenoh-flow"
+repository = "https://github.com/eclipse-zenoh-flow/zenoh-flow"
 version = "0.6.0-dev"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ The best way to learn Zenoh-Flow is to go through our [getting started guide](ht
 
 ## Examples
 
-We encourage you to look at the examples available in our [examples repository](https://github.com/ZettaScaleLabs/zenoh-flow-examples).
+We encourage you to look at the examples available in our [examples folder](./examples).
 
 🚗 If you still want more, we also ported an [Autonomous Driving Pipeline](https://github.com/ZettaScaleLabs/stunt)!

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 
 [![Eclipse CI](https://ci.eclipse.org/zenoh/buildStatus/icon?job=zenoh-flow-nightly&subject=Eclipse%20CI)](https://ci.eclipse.org/zenoh/view/Zenoh%20Flow/job/zenoh-flow-nightly/)
-[![CI](https://github.com/eclipse-zenoh/zenoh-flow/actions/workflows/ci.yml/badge.svg)](https://github.com/eclipse-zenoh/zenoh-flow/actions/workflows/ci.yml)
-[![Discussion](https://img.shields.io/badge/discussion-on%20github-blue)](https://github.com/eclipse-zenoh/roadmap/discussions)
+[![CI](https://github.com/eclipse-zenoh-flow/zenoh-flow/actions/workflows/ci.yml/badge.svg)](https://github.com/eclipse-zenoh-flow/zenoh-flow/actions/workflows/ci.yml)
+[![Discussion](https://img.shields.io/badge/discussion-on%20github-blue)](https://github.com/eclipse-zenoh-flow/roadmap/discussions)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-blue)](https://discord.gg/vSDSpqnbkm)
 
 
@@ -24,17 +24,17 @@ This makes for a powerful combination as Zenoh offers flexibility and extensibil
 
 -----
 
-🧑‍💻 We are currently keeping our documentation and guides in the [Wiki](https://github.com/eclipse-zenoh/zenoh-flow/wiki) tab of this repository.
+🧑‍💻 We are currently keeping our documentation and guides in the [Wiki](https://github.com/eclipse-zenoh-flow/zenoh-flow/wiki) tab of this repository.
 
 -----
 
 ## Installation
 
-Follow our guide [here](https://github.com/eclipse-zenoh/zenoh-flow/wiki/Installation-(v0.4.0))!
+Follow our guide [here](https://github.com/eclipse-zenoh-flow/zenoh-flow/wiki/Installation-(v0.4.0))!
 
 ## Getting Started
 
-The best way to learn Zenoh-Flow is to go through our [getting started guide](https://github.com/eclipse-zenoh/zenoh-flow/wiki/Getting-started-(v0.4.0)).
+The best way to learn Zenoh-Flow is to go through our [getting started guide](https://github.com/eclipse-zenoh-flow/zenoh-flow/wiki/Getting-started-(v0.4.0)).
 
 ## Examples
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,51 +1,60 @@
-# Zenoh-Flow examples
+# Zenoh-Flow Examples
 
-## How to run
+## Build
 
-### Build
+You can build the CLI with the following command:
+```bash
+cargo build
+```
 
-We can create all the zenoh-flow node libraries used in the examples with the following command:
+To build all the Zenoh-Flow node libraries used in the examples, run:
+```bash
+cargo build --examples
+```
+
+Alternatively, you can build a single Zenoh-Flow node library using the following command:
+```bash
+cargo build --example <node>
+```
+
+## Run the Examples
+
+The examples are organized into two folders:
+- [flows](./flows): Contains all the dataflow configuration files (`.yaml`).
+- [examples](./examples): Contains all the Rust source code for the nodes.
+
+You can run any flow **locally** with the following command:
+```bash
+./target/debug/zfctl run-local --vars TARGET_DIR=$(pwd)/target ./examples/flows/<name>.yaml
+```
+
+For example:
+```bash
+./target/debug/zfctl run-local --vars TARGET_DIR=$(pwd)/target ./examples/flows/getting-started.yaml
+```
+
+Additionally, you can override variables other than `TARGET_DIR`. For example:
+- `BUILD=debug` or `BUILD=release`
+- `DLL_EXTENSION=so`, `DLL_EXTENSION=dylib`, or `DLL_EXTENSION=dll`
+
+### Getting Started
+
+This example writes everything it receives under the key expression `zf/getting-started/hello` into the file `/tmp/greetings.txt`.
+
+1. Run the dataflow:
    ```bash
-  cargo build --examples
+   ./target/debug/zfctl run-local --vars TARGET_DIR=$(pwd)/target ./examples/flows/getting-started.yaml
    ```
 
-Alternatively, we can create a single library of a zenoh-flow node with the following command:
+2. Monitor the output file:
    ```bash
-  cargo build --example <node>
+   tail -f /tmp/greetings.txt
    ```
 
-### Configure and run the examples
-
-We first have to update all the occurrences of `{{ BASE_DIR }}` in the YAML descriptors to match our system.
-
-#### Launch the flow
-
-```shell
-./target/debug/zfctl launch ~/dev/zenoh-flow/examples/data-flow.yaml
-```
-
-If you have enabled the REST plugin of Zenoh
-```shell
-curl -X PUT -d 'world' http://localhost:8000/zf/getting-started/hello
-```
-
-For the "period-miss-detector" example:
-
-```shell
-curl -X PUT -d '2340' http://localhost:8000/zf/period-miss-detector
-```
-#### Show the result:
-
-The Sink node used in both examples creates a text file where the node writes the strings it receives.
-We can see the "getting-started" test file with:
-
-```
-tail -f /tmp/greetings.txt
-```
-
-For the "period-miss-detector" example:
-
-```
-tail -f /tmp/period-log.txt
-```
-
+3. Publish a message to `zf/getting-started/hello`. This can be done using a `zenohd` router with REST enabled:
+   ```bash
+   zenohd --rest-http-port 8000
+   ```
+   ```bash
+   curl -X PUT -d 'world' http://localhost:8000/zf/getting-started/hello
+   ```

--- a/zenoh-flow-descriptors/src/nodes/builtin/zenoh.rs
+++ b/zenoh-flow-descriptors/src/nodes/builtin/zenoh.rs
@@ -108,7 +108,7 @@ They will thus **both** receive the same publications.
 If this is a desired behaviour, you can safely ignore this message.
 
 For more details, see:
-https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md#canon-forms
+https://github.com/eclipse-zenoh-flow/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md#canon-forms
 "#,
                 owned_canon_ke,
                 key_expr,

--- a/zenoh-flow-records/src/lib.rs
+++ b/zenoh-flow-records/src/lib.rs
@@ -23,7 +23,7 @@
 //! # ⚠️ Internal usage
 //!
 //! This crate is (mostly) intended for internal usage within the
-//! [Zenoh-Flow](https://github.com/eclipse-zenoh/zenoh-flow) project.
+//! [Zenoh-Flow](https://github.com/eclipse-zenoh-flow/zenoh-flow) project.
 
 mod connectors;
 mod dataflow;

--- a/zenoh-flow-runtime/src/loader/extensions.rs
+++ b/zenoh-flow-runtime/src/loader/extensions.rs
@@ -154,7 +154,7 @@ impl Extensions {
 /// ```
 ///
 /// [shared libraries]: std::env::consts::DLL_EXTENSION
-/// [Python scripts]: https://github.com/eclipse-zenoh/zenoh-flow-python
+/// [Python scripts]: https://github.com/eclipse-zenoh-flow/zenoh-flow-python
 // NOTE: We separate the libraries in its own dedicated structure to have that same textual representation (YAML/JSON).
 //       There is no real need to do so.
 #[derive(Debug, Clone, Deserialize, Hash, PartialEq, Eq)]

--- a/zfctl/src/main.rs
+++ b/zfctl/src/main.rs
@@ -36,7 +36,7 @@ const ZENOH_FLOW_INTERNAL_ERROR: &str = r#"
 
 If the above error log does not help you troubleshoot the reason, you can contact us on:
 - Discord:  https://discord.gg/CeJB5rxk9x
-- GitHub:   https://github.com/eclipse-zenoh/zenoh-flow
+- GitHub:   https://github.com/eclipse-zenoh-flow/zenoh-flow
 "#;
 
 /// Macro to facilitate the creation of a [Row](comfy_table::Row) where its contents are not of the same type.


### PR DESCRIPTION
This PR updates the documentation for the examples and links to the relevant documentation:

- All mentions of `eclipse-zenoh/zenoh-flow` have been replaced with `eclipse-zenoh-flow/zenoh-flow`.
- The [examples README](./examples/README.md) has been updated to reflect the current examples, including a straightforward way to launch a dataflow using the `run-local` command.