### PR TITLE
refactor(zfctl): improve logs

### DIFF
--- a/zfctl/src/instance_command.rs
+++ b/zfctl/src/instance_command.rs
@@ -154,13 +154,17 @@ Caused by:
                 };
 
                 match sample.result() {
-                    Ok(sample) => {
-                        tracing::info!(
-                            "If successful, the instance will have the id: {:?}",
-                            sample.payload().try_to_string()
-                        );
-                        println!("{:?}", sample.payload().try_to_string());
-                    }
+                    Ok(sample) => match sample.payload().try_to_string() {
+                        Ok(instance_id) => {
+                            tracing::info!("Instance: {instance_id}");
+                            tracing::info!(
+                                "To check its status:\n\tzfctl instance status {instance_id}",
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to parse Instance ID: {e:?}");
+                        }
+                    },
                     Err(err) => tracing::error!("Failed to create instance: {:?}", err),
                 }
             }

--- a/zfctl/src/utils.rs
+++ b/zfctl/src/utils.rs
@@ -15,7 +15,7 @@
 use itertools::Itertools;
 use rand::Rng;
 use zenoh::{query::ConsolidationMode, Session};
-use zenoh_flow_commons::RuntimeId;
+use zenoh_flow_commons::{Result, RuntimeId};
 use zenoh_flow_daemon::queries::{selector_all_runtimes, RuntimeInfo, RuntimesQuery};
 
 /// Returns the list of [RuntimeInfo] of the reachable Zenoh-Flow Daemon(s).
@@ -26,17 +26,27 @@ use zenoh_flow_daemon::queries::{selector_all_runtimes, RuntimeInfo, RuntimesQue
 /// - (internal error) the query to list the Zenoh-Flow Daemons could not be serialised by `serde_json`,
 /// - the query on the Zenoh network failed,
 /// - no Zenoh-Flow Daemon is reachable.
-pub(crate) async fn get_all_runtimes(session: &Session) -> Vec<RuntimeInfo> {
-    let value = serde_json::to_vec(&RuntimesQuery::List)
-        .unwrap_or_else(|e| panic!("`serde_json` failed to serialize `RuntimeQuery::List`: {e:?}"));
+pub(crate) async fn get_all_runtimes(session: &Session) -> Result<Vec<RuntimeInfo>> {
+    tracing::debug!("Fetching available Zenoh-Flow Daemon(s)");
+    let value = match serde_json::to_vec(&RuntimesQuery::List) {
+        Ok(value) => value,
+        Err(e) => {
+            anyhow::bail!("`serde_json` failed to serialize `RuntimeQuery::List`: {e:?}");
+        }
+    };
 
-    let runtime_replies = session
+    let runtime_replies = match session
         .get(selector_all_runtimes())
         .payload(value)
         // We want to address all the Zenoh-Flow daemons that are reachable on the Zenoh network.
         .consolidation(ConsolidationMode::None)
         .await
-        .unwrap_or_else(|e| panic!("Failed to query available daemons:\n{:?}", e));
+    {
+        Ok(replies) => replies,
+        Err(e) => {
+            anyhow::bail!("Failed to send Query to Zenoh-Flow Daemon(s): {:?}", e);
+        }
+    };
 
     let mut runtimes = Vec::new();
     while let Ok(reply) = runtime_replies.recv_async().await {
@@ -45,23 +55,21 @@ pub(crate) async fn get_all_runtimes(session: &Session) -> Vec<RuntimeInfo> {
                 match serde_json::from_slice::<RuntimeInfo>(&sample.payload().to_bytes()) {
                     Ok(runtime_info) => runtimes.push(runtime_info),
                     Err(e) => {
-                        tracing::error!("Failed to parse a reply as a `RuntimeId`:\n{:?}", e)
+                        tracing::error!("Failed to parse a reply as a `RuntimeId`: {:?}", e)
                     }
                 }
             }
-
-            Err(e) => tracing::warn!("A reply returned an error:\n{:?}", e),
+            Err(e) => tracing::warn!("A reply returned an error: {:?}", e),
         }
     }
 
     if runtimes.is_empty() {
-        panic!(
-            "No Zenoh-Flow daemon were detected. Have you checked if (i) they are up and (ii) \
-             reachable through Zenoh?"
-        );
+        anyhow::bail!("Found no Zenoh-Flow Daemon on the network");
     }
 
-    runtimes
+    tracing::debug!("Found {} Zenoh-Flow Daemon(s)", runtimes.len());
+
+    Ok(runtimes)
 }
 
 /// Returns the unique identifier of the Zenoh-Flow Daemon that has the provided `name`.
@@ -71,26 +79,26 @@ pub(crate) async fn get_all_runtimes(session: &Session) -> Vec<RuntimeInfo> {
 /// This function will panic if:
 /// - there is no Zenoh-Flow Daemon that has the provided name,
 /// - there are more than 1 Zenoh-Flow Daemon with the provided name.
-pub(crate) async fn get_runtime_by_name(session: &Session, name: &str) -> RuntimeId {
-    let runtimes = get_all_runtimes(session).await;
+pub(crate) async fn get_runtime_by_name(session: &Session, name: &str) -> Result<RuntimeId> {
+    let runtimes = get_all_runtimes(session).await?;
     let mut matching_runtimes = runtimes
         .iter()
         .filter(|&r_info| r_info.name.as_ref() == name)
         .collect_vec();
 
     if matching_runtimes.is_empty() {
-        panic!("Found no Zenoh-Flow Daemon with name < {name} >");
+        anyhow::bail!("Found no Zenoh-Flow Daemon with name < {name} >");
     } else if matching_runtimes.len() > 1 {
-        tracing::error!("Found multiple Zenoh-Flow Daemons named < {name} >:");
+        tracing::error!("Found multiple Zenoh-Flow Daemon named < {name} >:");
         matching_runtimes.iter().for_each(|&r_info| {
             tracing::error!("- {} - (id) {}", r_info.name, r_info.id);
         });
-        panic!(
-            "There are multiple Zenoh-Flow Daemons named < {name} >, please use their 'id' \
+        anyhow::bail!(
+            "There are multiple Zenoh-Flow Daemons named < {name} >, please use their 'zid' \
              instead"
         );
     } else {
-        matching_runtimes.pop().unwrap().id.clone()
+        Ok(matching_runtimes.pop().unwrap().id.clone())
     }
 }
 
@@ -102,9 +110,15 @@ pub(crate) async fn get_runtime_by_name(session: &Session, name: &str) -> Runtim
 /// - (internal error) the query to list the Zenoh-Flow Daemons could not be serialised by `serde_json`,
 /// - the query on the Zenoh network failed,
 /// - no Zenoh-Flow Daemon is reachable.
-pub(crate) async fn get_random_runtime(session: &Session) -> RuntimeId {
-    let mut runtimes = get_all_runtimes(session).await;
+pub(crate) async fn get_random_runtime(session: &Session) -> Result<RuntimeId> {
+    let mut runtimes = get_all_runtimes(session).await?;
     let orchestrator = runtimes.remove(rand::thread_rng().gen_range(0..runtimes.len()));
 
-    orchestrator.id
+    tracing::info!(
+        "Selected Zenoh-Flow Daemon < {}: {} > as Orchestrator",
+        orchestrator.name,
+        orchestrator.id
+    );
+
+    Ok(orchestrator.id)
 }


### PR DESCRIPTION
This commit brings some improvements to the outputted logs when launching `zfctl` and the `zfctl daemon` command.

The most notable additions are:
- when starting a Zenoh-Flow Daemon, its name and Zenoh ID will be logged,
- the `RUST_LOG` environment variable will be used if specified,
- the default logging level was set to `zfctl=info,zenoh_flow=info`.

* zfctl/src/daemon_command.rs:
  - Added a `span` at the top of the `run` method to be used within the `async` block.
  - Reworked the code to not `panic!` when an error occurred but instead return it and/or add logs.
* zfctl/src/instance_command.rs:
  - Properly display the id of the newly created instance.
  - Display a command to check for the status of a newly created instance.
* zfctl/src/main.rs:
  - Read the environment variable RUST_LOG to control the logs.
  - Set the default logging to `zfctl=info,zenoh_flow=info`.
  - Instrument the async block using a span.
* zfctl/src/run_local_command.rs:
  - Reworked the code to not panic when an error occurred but instead return it and/or add logs.
* zfctl/src/utils.rs:
  - Reworked the code to not panic when an error occurred but instead return it and/or add logs.